### PR TITLE
Add support for special keys and function keys

### DIFF
--- a/AdhocTest/Module1.vb
+++ b/AdhocTest/Module1.vb
@@ -125,13 +125,23 @@ Module Module1
         gw.WaitUntilKeyAvailable()
         'gw.EmptyKeys()
 
+        Dim numKeysPressed As Integer = 0
+        gw.CaptureModifierKeys = True
         While gw.IsLiving
-            Dim k = gw.ReadKey()
-            If IsNothing(k) Then Exit While
-            If k.KeyCode = System.Windows.Forms.Keys.Escape Then Exit While
+            Dim keyInfo = gw.ReadKeyInfo()
+            Dim key = keyInfo.Key
+            If IsNothing(key) Then Exit While
+            If key.KeyCode = System.Windows.Forms.Keys.Escape Then Exit While
             gw.Clear(Color.Black)
-            Dim s As String = String.Format("Key: {0}, Keyvalue: {1}", k.KeyData, k.KeyValue)
+
+            numKeysPressed += 1
+            Dim s As String = String.Format("Key: {0}, Keyvalue: {1}", key.KeyData, key.KeyValue)
             gw.DrawText(s, 10, 10, Color.White, "Consolas", 12)
+            s = String.Format("Keychar code: {0}, Keychar: {1}", Convert.ToInt32(keyInfo.KeyChar),
+                              keyInfo.KeyChar)
+            gw.DrawText(s, 10, 26, Color.White, "Consolas", 12)
+            s = String.Format("Number of keys pressed: {0}", numKeysPressed)
+            gw.DrawText(s, 10, 42, Color.White, "Consolas", 12)
             gw.DrawLine(0, 0, 99, 399, Color.White)
             gw.DrawLine(50, 0, 149, 399, Color.White, 1.5F)
             gw.DrawLineWithSmoothing(100, 0, 199, 399, Color.White)

--- a/Test/GraphicsWindowTest.vb
+++ b/Test/GraphicsWindowTest.vb
@@ -117,6 +117,41 @@ Public Class GraphicsWindowTest
     End Sub
 
     <Fact>
+    Public Sub SpecialKeys()
+        gw.Form.BringToFront()
+        Application.DoEvents()
+
+        Assert.False(gw.KeyAvailable)
+        Assert.StrictEqual(New KeyInfo(Nothing, ControlChars.NullChar), gw.ReadKeyInfoIfAvailable)
+
+        ' Only tests some of the keys because the rest cannot be emulated with SendKeys. Keys that
+        ' are not tested are Pause, Numpad 5 (without number lock), Ctrl, Alt, Shift, Menu, F10,
+        ' and F17 to F24. Note that F10 is not tested because it activates the menu bar and
+        ' and therefore makes tests to fail.
+        Dim keysToTest As Keys() = {
+            Keys.F1, Keys.F2, Keys.F3, Keys.F4, Keys.F5, Keys.F6, Keys.F7, Keys.F8, Keys.F9,
+            Keys.F11, Keys.F12, Keys.F13, Keys.F14, Keys.F15, Keys.F16, Keys.Up, Keys.Down,
+            Keys.Left, Keys.Right, Keys.PageUp, Keys.PageDown, Keys.Home, Keys.End, Keys.Insert,
+            Keys.Delete, Keys.CapsLock, Keys.NumLock, Keys.Scroll
+        }
+        SendKeys.SendWait("{F1}{F2}{F3}{F4}{F5}{F6}{F7}{F8}{F9}{F11}{F12}{F13}{F14}{F15}{F16}{UP}" +
+                          "{DOWN}{LEFT}{RIGHT}{PGUP}{PGDN}{HOME}{END}{INS}{DEL}{CAPSLOCK}" +
+                          "{NUMLOCK}{SCROLLLOCK}")
+
+        For Each keyToTest In keysToTest
+            Assert.True(gw.KeyAvailable)
+            Dim key As KeyInfo = gw.ReadKeyInfo()
+            Assert.StrictEqual(keyToTest, key.Key.KeyData)
+            Assert.StrictEqual(ControlChars.NullChar, key.KeyChar)
+        Next
+
+        ' Cannot assert that the key buffer is empty here because caps lock, number lock and scroll
+        ' lock get registered in the buffer twice. We have manually tested that if those keys are
+        ' pressed in the keyboard instead of by SendKeys, each of them registers only once in the
+        ' buffer.
+    End Sub
+
+    <Fact>
     Public Sub EmptyKeys()
         gw.Form.BringToFront()
         Application.DoEvents()

--- a/VBGraphics/GraphicsWindow.vb
+++ b/VBGraphics/GraphicsWindow.vb
@@ -4,6 +4,7 @@ Imports System
 Imports System.Collections.Generic
 Imports System.ComponentModel
 Imports System.Drawing
+Imports System.Linq
 Imports System.Windows.Forms
 
 <Assembly: CLSCompliant(True)>
@@ -43,6 +44,7 @@ Namespace Global.VBGraphics
 
         ReadOnly Property IsLiving As Boolean = True
         Property CanClose As Boolean = False
+        Property CaptureModifierKeys As Boolean = False
 
         ReadOnly Property Form As Form
             Get
@@ -102,7 +104,7 @@ Namespace Global.VBGraphics
         End Function
 
         Public Sub WaitUntilKeyAvailable()
-            While Not KeyAvailable And IsLiving
+            While Not KeyAvailable AndAlso IsLiving
                 Application.DoEvents()
             End While
         End Sub
@@ -111,12 +113,34 @@ Namespace Global.VBGraphics
             _keys.Clear()
         End Sub
 
+        Private Shared ReadOnly nonKeyPressKeys As Keys() = {
+            Keys.F1, Keys.F2, Keys.F3, Keys.F4, Keys.F5, Keys.F6, Keys.F7, Keys.F8, Keys.F9,
+            Keys.F10, Keys.F11, Keys.F12, Keys.F13, Keys.F14, Keys.F15, Keys.F16, Keys.F17,
+            Keys.F18, Keys.F19, Keys.F20, Keys.F21, Keys.F22, Keys.F23, Keys.F24, Keys.Up,
+            Keys.Down, Keys.Left, Keys.Right, Keys.PageUp, Keys.PageDown, Keys.Home, Keys.End,
+            Keys.Insert, Keys.Delete, Keys.Pause, Keys.Clear, Keys.CapsLock, Keys.NumLock,
+            Keys.Scroll, Keys.Apps
+        }
+
+        Private Shared ReadOnly modifierKeys As Keys() = {
+            Keys.ControlKey, Keys.ShiftKey, Keys.Menu
+        }
+
         Private Sub _Form_KeyDown(sender As Object, e As KeyEventArgs) Handles _Form.KeyDown
             _currentKey = e
+            If nonKeyPressKeys.Contains(e.KeyCode) OrElse
+               _CaptureModifierKeys AndAlso modifierKeys.Contains(e.KeyCode) Then
+                _keys.Enqueue(New KeyInfo(_currentKey, Microsoft.VisualBasic.ControlChars.NullChar))
+            End If
         End Sub
 
         Private Sub _Form_KeyPress(sender As Object, e As KeyPressEventArgs) Handles _Form.KeyPress
             _keys.Enqueue(New KeyInfo(_currentKey, e.KeyChar))
+        End Sub
+
+        Private Sub _Form_PreviewKeyDown(sender As Object, e As PreviewKeyDownEventArgs) _
+            Handles _Form.PreviewKeyDown
+            e.IsInputKey = True
         End Sub
 #End Region
 

--- a/VBGraphics/GraphicsWindowText.vb
+++ b/VBGraphics/GraphicsWindowText.vb
@@ -100,7 +100,8 @@ Namespace Global.VBGraphics
 
             Public Property IsInputFinished As Boolean = False
 
-            Private Sub CustomTextBox_KeyPress(sender As Object, e As KeyPressEventArgs) Handles Me.KeyPress
+            Private Sub CustomTextBox_KeyPress(sender As Object, e As KeyPressEventArgs) _
+                Handles Me.KeyPress
                 If e.KeyChar = Microsoft.VisualBasic.ControlChars.Cr Then
                     IsInputFinished = True
                 End If


### PR DESCRIPTION
- Most special keys and function keys are handled
- Keys that are chosen NOT to be handled: PrtScn
- Keys that are handled but will cause problems: Alt, F10
- Ctrl, Alt and Shift are captured only when CaptureModifierKeys is True