### PR TITLE
KeyAvailable now process windows message

### DIFF
--- a/VBGraphics/GraphicsWindow.vb
+++ b/VBGraphics/GraphicsWindow.vb
@@ -71,6 +71,7 @@ Namespace Global.VBGraphics
 #Region "Key Handlers"
         ReadOnly Property KeyAvailable As Boolean
             Get
+                Application.DoEvents()
                 Return _keys.Count > 0
             End Get
         End Property
@@ -105,7 +106,6 @@ Namespace Global.VBGraphics
 
         Public Sub WaitUntilKeyAvailable()
             While Not KeyAvailable AndAlso IsLiving
-                Application.DoEvents()
             End While
         End Sub
 


### PR DESCRIPTION
When we query KeyAvailable we want to process all windows message for
key inputs. So DoEvents is executed before checking the key queue.

As a side effect, KeyAvailable cause the invalidated canvas to redraw.